### PR TITLE
Fix schrödinger's packages

### DIFF
--- a/pkgtxt
+++ b/pkgtxt
@@ -26,7 +26,7 @@ update() {
     to_install=$(mktemp)
     to_remove=$(mktemp)
     pacqeq=$(mktemp)
-    pacman -Qeq > $pacqeq
+    pacman -Qeq | sort > $pacqeq
 
     diff $pkgtxt_sorted $pacqeq | grep "^< " | awk '{print $2}' > $to_install
     diff $pkgtxt_sorted $pacqeq | grep "^> " | awk '{print $2}' > $to_remove


### PR DESCRIPTION
pacman's sort order seems to be different than the one of sort(1), which
caused packages to appear in both sides of the diff